### PR TITLE
add light switch to menu!

### DIFF
--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -7,15 +7,6 @@ template:
     border-radius: 0.5rem
     btn-border-radius: 0.25rem
 
-navbar:
-  structure:
-    left:  [intro, reference, articles, news]
-    right: [search, github]
-  components:
-    news:
-      text: Changelog
-      href: news/index.html
-
 articles:
   - title: Get Started
     navbar: ~


### PR DESCRIPTION
I think the froggeR package looks interesting! However, I prefer to read in light mode. Naturally, I took a peak at your pkgdown config and noticed a tiny issue :)

This is because the light needs to be specified in the config. https://pkgdown.r-lib.org/articles/customise.html?q=light%20sw#navbar-heading

However, since you use the default config. We can simply delete this!

Cheers